### PR TITLE
Fixed hud freeze when enabling cinematic bars

### DIFF
--- a/web/src/components/Player.tsx
+++ b/web/src/components/Player.tsx
@@ -50,8 +50,8 @@ const Player: React.FC = () => {
         setPosition(data.hudPosition);
     });
 
-    useNuiEvent('HUDSettings', (data) => {
-        setOpened(true);
+    useNuiEvent('HUDSettings', (data: boolean) => {
+        setOpened(data);
     });
 
     useNuiEvent<any>('player', (data) => {


### PR DESCRIPTION
If you enable the cinematic bars, the HUD settings will stay in place and you will be able to move, with this fix, the HUD configuration will slide out.