### PR TITLE
Fixed hud freeze when enabling cinematic bars

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -209,6 +209,9 @@ RegisterNUICallback('toggleCinematicBars', function(data, cb)
         TriggerEvent('ts_hud:client:showHud')
     end
 
+    -- Close HUD settings
+    hideSettingsMenu()
+
     -- Notify the NUI that the operation was successful
     cb({ status = 'success', message = 'Cinematic bars ' .. (data.enabled and 'disabled') })
 end)

--- a/web/src/components/Player.tsx
+++ b/web/src/components/Player.tsx
@@ -50,8 +50,8 @@ const Player: React.FC = () => {
         setPosition(data.hudPosition);
     });
 
-    useNuiEvent('HUDSettings', (data) => {
-        setOpened(true);
+    useNuiEvent('HUDSettings', (data: boolean) => {
+        setOpened(data);
     });
 
     useNuiEvent<any>('player', (data) => {


### PR DESCRIPTION
If you enable the cinematic bars, the HUD settings will stay in place and you will be able to move, with this fix, the HUD configuration will slide out.