### PR TITLE
Make stress system compatible with qbcore & qbox

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -422,6 +422,8 @@ CreateThread(function()
         else
             if showingPlayerHUD then
                 ShowNUI('setVisiblePlayer', false, false)
+                ShowNUI('setVisibleVehicle', false, false)
+                showingVehicleHUD = false
                 showingPlayerHUD = false
             end
             Wait(500)

--- a/server/main.lua
+++ b/server/main.lua
@@ -13,7 +13,7 @@ RegisterNetEvent('hud:server:GainStress', function(amount)
     if not Config.stress.enableStress then return end
 
     local src = source
-    local player = exports.qbx_core:GetPlayer(src)
+    local player = Config.core.Functions.GetPlayer(src)
     local newStress
     if not player then return end
     if not resetStress then
@@ -40,7 +40,7 @@ RegisterNetEvent('hud:server:RelieveStress', function(amount)
     if not Config.stress.enableStress then return end
 
     local src = source
-    local player = exports.qbx_core:GetPlayer(src)
+    local player = Config.core.Functions.GetPlayer(src)
     local newStress
     if not player then return end
     if not resetStress then


### PR DESCRIPTION
I changed the qbox export to qbcore & qbox functions, so it's compatible with both frameworks.